### PR TITLE
make a failing docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,54 +2,22 @@ name: docker-build
 
 on:
   push:
-    branches:
-      - 'dev'
-      - 'main'
+  workflow_dispatch:
 
 jobs:
-  # build container
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          tags: cohenaj194/flask-test
-
-  # # push container
-  # restart-deployment:
-  #   runs-on: ubuntu-latest # Specifies the runner environment
-  #   needs: docker
-
-  #   steps:
-  #   - name: Checkout code
-  #     uses: actions/checkout@v2 # Checks out your repository under $GITHUB_WORKSPACE
-
-  #   - name: Set up Kubectl
-  #     uses: azure/setup-kubectl@v3 # Updated to version 3 to fix the vulnerability
-  #     with:
-  #       version: 'v1.20.0' # Specify the version of kubectl you want to use
-
-  #   - name: Configure Kubeconfig
-  #     env:
-  #       KUBECONFIG_STAGING: ${{ secrets.KUBECONFIG_STAGING }} # Uses the secret encoded in base64
-  #     run: |
-  #       echo "$KUBECONFIG_STAGING" | base64 -d > kubeconfig
-  #       export KUBECONFIG=$(pwd)/kubeconfig
-
-  #   - name: Rollout Restart Deployment
-  #     run: kubectl rollout restart deployment flask-test --kubeconfig kubeconfig
+          push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,13 @@
-# start by pulling the python image
-FROM python:3.11-alpine
+# syntax=docker/dockerfile:1
 
-# copy the requirements file into the image
-COPY ./ /app/
+# Alpine is chosen for its small footprint
+# compared to Ubuntu
 
-# switch working directory
-WORKDIR /app
+FROM python:slim-bookworm
 
-# install the dependencies and packages in the requirements file
-RUN pip install -r requirements.txt
+# install packages
+RUN pip3 install tenacity requests PyQt5 \
+    && apt-get update \
+    && apt-get install -y libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
 
-# configure the container to run in an executed manner
-ENV FLASK_APP=app.py
-EXPOSE 5000
-ENTRYPOINT [ "python" ]
-CMD ["app.py"]
-
-## DOCKER COMMANDS
-#  docker build -t flask-test .
-#  docker run -dit --name test -p 5000:5000 flask-test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the GitHub Actions workflow configuration to trigger the Docker build on manual workflow dispatch events instead of pushes to `dev` and `main` branches.
  - Simplified the Docker image build and push steps in the GitHub Actions workflow.
  - Updated the base Docker image from `python:3.11-alpine` to `python:slim-bookworm` and simplified the installation of dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->