### PR TITLE
add prisma

### DIFF
--- a/.prismalintrc.json
+++ b/.prismalintrc.json
@@ -1,0 +1,36 @@
+{
+  "rules": {
+    "field-name-mapping-snake-case": [
+      "error",
+      {
+        "compoundWords": ["S3"]
+      }
+    ],
+    "field-order": [
+      "error",
+      {
+        "order": ["tenantId", "..."]
+      }
+    ],
+    "forbid-required-ignored-field": ["error"],
+    "model-name-grammatical-number": [
+      "error",
+      {
+        "style": "singular"
+      }
+    ],
+    "model-name-mapping-snake-case": [
+      "error",
+      {
+        "compoundWords": ["GraphQL"]
+      }
+    ],
+    "require-field-index": [
+      "error",
+      {
+        "forAllRelations": true,
+        "forNames": ["tenantId"]
+      }
+    ]
+  }
+}

--- a/example.prisma
+++ b/example.prisma
@@ -1,0 +1,35 @@
+generator client {
+  provider        = "prisma-client-js"
+  output          = "../generated/prisma/client"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = "fake-url"
+}
+
+model Users {
+  id           String @id
+  emailAddress String
+  tenantId     String
+  removeMe     String @ignore
+  tenant       Tenant @relation(fields: [tenantId], references: [id])
+  @@map(name: "users")
+}
+
+model Tenant {
+  id         String @id
+  name       String
+  @@map(name: "tenant")
+}
+
+model UserRoleFoo {
+  id         String @id
+  @@map(name: "unexpected_snake_case")
+}
+
+model UserRole {
+  id         String @id
+  userId     String @map(name: "userid")
+  // No mapping.
+}


### PR DESCRIPTION
fuck this error

```
Deprecation: [@octokit/request-error] `error.code` is deprecated, use `error.status`.
    at RequestError.get (/Users/alex/Repos/mono/pr-reviewer-saas/node_modules/.pnpm/@octokit+request-error@5.1.0/node_modules/@octokit/request-error/dist-node/index.js:70:11)
    at JSON.stringify (<anonymous>)
    at parseOwn (/Users/alex/Repos/mono/packages/common/src/winston/error.ts:61:26)
    at parseError (/Users/alex/Repos/mono/packages/common/src/winston/error.ts:41:42)
    at Printf.template (/Users/alex/Repos/mono/packages/common/src/winston/google_cloud.ts:20:22)
    at Printf.transform (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/logform@2.7.0/node_modules/logform/printf.js:11:26)
    at Format.transform (/Users/alex/Repos/mono/pr-reviewer-saas/node_modules/.pnpm/logform@2.7.0/node_modules/logform/combine.js:20:24)
    at DerivedLogger._transform (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/winston@3.17.0/node_modules/winston/lib/winston/logger.js:314:29)
    at Transform._read (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_transform.js:166:10)
    at Transform._write (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_transform.js:155:83)
    at doWrite (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_writable.js:390:139)
    at writeOrBuffer (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_writable.js:381:5)
    at Writable.write (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_writable.js:302:11)
    at DerivedLogger.log (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/winston@3.17.0/node_modules/winston/lib/winston/logger.js:253:14)
    at DerivedLogger.<computed> [as error] (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/winston@3.17.0/node_modules/winston/lib/winston/create-logger.js:95:19)
    at sentryCaptureException (/Users/alex/Repos/mono/pr-reviewer-saas/src/utils/utils.ts:43:21)
Deprecation: [@octokit/request-error] `error.headers` is deprecated, use `error.response.headers`.
    at RequestError.get (/Users/alex/Repos/mono/pr-reviewer-saas/node_modules/.pnpm/@octokit+request-error@5.1.0/node_modules/@octokit/request-error/dist-node/index.js:80:11)
    at JSON.stringify (<anonymous>)
    at parseOwn (/Users/alex/Repos/mono/packages/common/src/winston/error.ts:61:26)
    at parseError (/Users/alex/Repos/mono/packages/common/src/winston/error.ts:41:42)
    at Printf.template (/Users/alex/Repos/mono/packages/common/src/winston/google_cloud.ts:20:22)
    at Printf.transform (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/logform@2.7.0/node_modules/logform/printf.js:11:26)
    at Format.transform (/Users/alex/Repos/mono/pr-reviewer-saas/node_modules/.pnpm/logform@2.7.0/node_modules/logform/combine.js:20:24)
    at DerivedLogger._transform (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/winston@3.17.0/node_modules/winston/lib/winston/logger.js:314:29)
    at Transform._read (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_transform.js:166:10)
    at Transform._write (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_transform.js:155:83)
    at doWrite (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_writable.js:390:139)
    at writeOrBuffer (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_writable.js:381:5)
    at Writable.write (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/readable-stream@3.6.2/node_modules/readable-stream/lib/_stream_writable.js:302:11)
    at DerivedLogger.log (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/winston@3.17.0/node_modules/winston/lib/winston/logger.js:253:14)
    at DerivedLogger.<computed> [as error] (/Users/alex/Repos/mono/packages/common/node_modules/.pnpm/winston@3.17.0/node_modules/winston/lib/winston/create-logger.js:95:19)
    at sentryCaptureException (/Users/alex/Repos/mono/pr-reviewer-saas/src/utils/utils.ts:43:21)
```